### PR TITLE
Busqueda por nombre de evento

### DIFF
--- a/src/main/kotlin/ar/edu/unsam/pds/repository/CourseRepository.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/repository/CourseRepository.kt
@@ -39,15 +39,19 @@ interface CourseRepository : JpaRepository<Course, UUID> {
                 SELECT 1 FROM c.programs p 
                 WHERE LOWER(p.name) LIKE LOWER(CONCAT('%', :query, '%'))
             )
+             OR EXISTS (
+                 SELECT 1 FROM c.events e 
+                 JOIN e.schedules s 
+                 JOIN s.assignedUsers u 
+                 WHERE LOWER(CONCAT(u.name, ' ', u.lastName)) 
+                 LIKE LOWER(CONCAT('%', REPLACE(:query, ' ', '%'), '%'))
+             )
             OR EXISTS (
-                SELECT 1 FROM c.events e 
-                JOIN e.schedules s 
-                JOIN s.assignedUsers u 
-                WHERE LOWER(CONCAT(u.name, ' ', u.lastName)) 
-                LIKE LOWER(CONCAT('%', REPLACE(:query, ' ', '%'), '%'))
+                SELECT 1 FROM c.events e
+                WHERE LOWER(e.name) LIKE LOWER(CONCAT('%', :query, '%'))
             )
         ORDER BY hasEvents, c.name
     """)
-    fun searchByNameOrProgramOrProfessor(@Param("query") query: String): List<Course>
+    fun searchByNameOrProgramOrProfessorOrEvent(@Param("query") query: String): List<Course>
 
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/services/CourseService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/CourseService.kt
@@ -17,7 +17,7 @@ class CourseService(
 
     fun searchBy(query: String): List<Course> {
         if (query.isNotBlank()) {
-            return courseRepository.searchByNameOrProgramOrProfessor(query).distinctBy { it.id }
+            return courseRepository.searchByNameOrProgramOrProfessorOrEvent(query).distinctBy { it.id }
         }
         return getAll()
     }


### PR DESCRIPTION
Cambio chico en el search, se agregó para que también busque por el nombre del evento (ya buscaba por nombre del curso, carrera y docente), por ejemplo si buscabas "PHM" en el search, no mostraba la card de la materia aunque el nombre del evento fuera "Cursada PHM".

<img width="556" height="388" alt="image" src="https://github.com/user-attachments/assets/e7491483-758b-4a76-ab44-135207fe1963" />

Se agregó otro `OR EXISTS` en la query del repo para buscar por nombre del evento y actualicé el nombre del método a `serachByNameOrProgramOrProfessorOrEvent` (capaz un poquito largo lol).

Closes #7 