### PR TITLE
Capacidad de aula

### DIFF
--- a/src/main/kotlin/ar/edu/unsam/pds/controllers/ClassroomController.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/controllers/ClassroomController.kt
@@ -1,0 +1,29 @@
+package ar.edu.unsam.pds.controllers
+
+import ar.edu.unsam.pds.dto.response.CustomResponse
+import ar.edu.unsam.pds.mappers.ClassroomMapper
+import ar.edu.unsam.pds.services.ClassroomService
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("api/classroom")
+@CrossOrigin("*")
+class ClassroomController : UUIDValid() {
+    @Autowired
+    private lateinit var classroomService: ClassroomService
+
+    @GetMapping("/{classroomID}")
+    @Operation(summary = "Get classroom by id")
+    fun getById(@PathVariable classroomID: String,): ResponseEntity<CustomResponse> {
+        return ResponseEntity.status(200).body(
+            CustomResponse (
+                message = "Aula obtenida con exito",
+                data = ClassroomMapper.buildClassroomDto(classroomService.getById(classroomID))
+            )
+        )
+    }
+
+}

--- a/src/main/kotlin/ar/edu/unsam/pds/repository/ClassroomRepository.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/repository/ClassroomRepository.kt
@@ -10,4 +10,6 @@ import java.util.*
 interface ClassroomRepository : JpaRepository<Classroom, UUID>{
 
     fun findByName(@Param("name") name: String): Optional<Classroom>
+
+    fun findClassroomByCode(code: String): Optional<Classroom>
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/security/FilterChainConfiguration.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/security/FilterChainConfiguration.kt
@@ -131,6 +131,9 @@ class FilterChainConfiguration {
                 // Buildings
                 antMatcher(GET, "/api/buildings"),
                 antMatcher(GET, "/api/buildings/*"),
+
+                // Classroom
+                antMatcher(GET, "/api/classroom/*"),
             ).permitAll()
 
             // H2 DataBase @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/src/main/kotlin/ar/edu/unsam/pds/services/ClassroomService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/ClassroomService.kt
@@ -1,0 +1,18 @@
+package ar.edu.unsam.pds.services
+
+import ar.edu.unsam.pds.exceptions.NotFoundException
+import ar.edu.unsam.pds.models.Classroom
+import ar.edu.unsam.pds.repository.ClassroomRepository
+import org.springframework.stereotype.Service
+
+@Service
+class ClassroomService(
+    private val classroomRepository: ClassroomRepository,
+) {
+    fun getById(classroomId: String): Classroom {
+        return classroomRepository.findClassroomByCode(classroomId).orElseThrow {
+            NotFoundException("Aula no encontrada para el código suministrado")
+        }
+    }
+
+}


### PR DESCRIPTION
Agregue el controller y service para obtener la informacion del aula segun su code. No estaba nada implementado de esto asi que tuve que crear los archivos desde cero y agregarlo en el archivo de seguridad para que el endpoint sea aceptado en el front y no tire 403. Por el momento se usa solo para mostrar la capacidad del aula pero si mas adelante queremos mostrar otra informacion del aula se puede aprovechar este endpoint.

Probar con la rama del front feat/limite-aulas

Closes #13