### PR TITLE
Logica para ver eventos institucionales solo para el Admin

### DIFF
--- a/src/main/kotlin/ar/edu/unsam/pds/bootstrap/InitEvents.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/bootstrap/InitEvents.kt
@@ -404,6 +404,98 @@ class InitEvents : BootstrapGeneric("Events") {
         ).apply { this.addPeriod(primerCuatrimestre) }
         eventRepository.save(parcialPHM)
 
+        /*...........:Eventos Institucionales:............*/
+        /*...........:En Curso:............*/
+        val charlaIA = Event(
+            name = "Introducción a la IA Generativa",
+            isApproved = true,
+            type = EventType.CHARLA,
+            details = "Charla abierta para estudiantes"
+        )
+
+        val seminarioReact = Event(
+            name = "React Avanzado",
+            isApproved = true,
+            type = EventType.SEMINARIO,
+            details = "Componentes y hooks"
+        )
+        eventRepository.save(charlaIA)
+        eventRepository.save(seminarioReact)
+        /*..............:Sin Iniciar:.............*/
+        val conferenciaCloud = Event(
+            name = "Cloud Computing",
+            isApproved = true,
+            type = EventType.CONFERENCIA,
+            details = "Infraestructura moderna"
+        )
+
+        val charlaKubernetes = Event(
+            name = "Kubernetes Básico",
+            isApproved = true,
+            type = EventType.CHARLA,
+            details = "Orquestación de contenedores"
+        )
+        eventRepository.save(conferenciaCloud)
+        eventRepository.save(charlaKubernetes)
+        /*..............:Finalizados:.............*/
+        val seminarioDocker = Event(
+            name = "Docker para Principiantes",
+            isApproved = true,
+            type = EventType.SEMINARIO,
+            details = "Seminario práctico"
+        )
+
+        val charlaGit = Event(
+            name = "Git y GitHub",
+            isApproved = true,
+            type = EventType.CHARLA,
+            details = "Control de versiones"
+        )
+        eventRepository.save(seminarioDocker)
+        eventRepository.save(charlaGit)
+
+        /*..............:Proximamente:.............*/
+        val conferenciaIndustria = Event(
+            name = "Transformación Digital",
+            isApproved = true,
+            type = EventType.CONFERENCIA,
+            details = "Conferencia institucional"
+        )
+
+        val charlaCiberseguridad = Event(
+            name = "Ciberseguridad Actual",
+            isApproved = true,
+            type = EventType.CHARLA,
+            details = "Amenazas y prevención"
+        )
+
+        val seminarioIA = Event(
+            name = "IA Aplicada",
+            isApproved = true,
+            type = EventType.SEMINARIO,
+            details = "Casos de uso reales"
+        )
+
+        val conferenciaDatos = Event(
+            name = "Data Science Summit",
+            isApproved = true,
+            type = EventType.CONFERENCIA,
+            details = "Análisis de datos"
+        )
+
+        /*Evento sin aprobar*/
+        val charlaQuimicaGeneral = Event(
+            name = "Introducción a la Tabla Periódica y Tendencias",
+            isApproved = null,
+            type = EventType.CHARLA,
+            details = "Análisis de la configuración electrónica, electronegatividad y radio atómico"
+        )
+
+        eventRepository.save(conferenciaIndustria)
+        eventRepository.save(charlaCiberseguridad)
+        eventRepository.save(seminarioIA)
+        eventRepository.save(conferenciaDatos)
+        eventRepository.save(charlaQuimicaGeneral)
       }
 
     fun findCourseByName(name: String): Course? {

--- a/src/main/kotlin/ar/edu/unsam/pds/bootstrap/InitSchedules.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/bootstrap/InitSchedules.kt
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.DependsOn
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 import java.time.DayOfWeek
+import java.time.LocalDate
 import java.time.LocalTime
 
 @Component(value = "InitSchedules.beanName")
@@ -60,6 +61,20 @@ class InitSchedules : BootstrapGeneric("Schedules") {
         val gastonAguilera=userByEmail("gAguilera@estudiantes.unsam.edu.ar")
         val monica=userByEmail("mHencek@estudiantes.unsam.edu.ar")
         val juanJoseLopez=userByEmail("jJLopez@estudiantes.unsam.edu.ar")
+
+        /*Horarios para Eventos*/
+        val charlaIA = findEvent("Introducción a la IA Generativa")
+        val seminarioDocker = findEvent("Docker para Principiantes")
+        val seminarioReact = findEvent("React Avanzado")
+        val conferenciaCloud = findEvent("Cloud Computing")
+        val charlaKubernetes = findEvent("Kubernetes Básico")
+        val charlaGit = findEvent("Git y GitHub")
+        val conferenciaIndustria = findEvent("Transformación Digital")
+        val charlaCiberseguridad = findEvent("Ciberseguridad Actual")
+        val seminarioIA = findEvent("IA Aplicada")
+        val conferenciaDatos = findEvent("Data Science Summit")
+        val charlaQuimicaGeneral = findEvent("Introducción a la Tabla Periódica y Tendencias")
+
 //        val event1 = findEvent("Cursada Algoritmos I")
        /*
         val event3 = findEvent("Final Matematica I")*/
@@ -689,6 +704,142 @@ class InitSchedules : BootstrapGeneric("Schedules") {
         }
         scheduleRepository.save(scheduleRedesInfo3Martes)
 
+        /*Horarios para los eventos Institucionales*/
+        //En curso
+        val scheduleCharlaIA = Schedule(
+                startTime = LocalTime.of(18, 0),
+                endTime = LocalTime.of(23, 0),
+                weekDay = null,
+                date = LocalDate.now(),
+                isVirtual = false
+        ).apply {
+            event = charlaIA
+            classroom = classroomRepository.findByName("Centro de investigacion y desarrollo de informatica").orElseThrow { NotFoundException("No se halló el aula") }
+        }
+        scheduleRepository.save(scheduleCharlaIA)
+
+        val scheduleSeminarioReact = Schedule(
+                startTime = LocalTime.of(20, 0),
+                endTime = LocalTime.of(23, 30),
+                weekDay = null,
+                date = LocalDate.now(),
+                isVirtual = false
+        ).apply {
+            event = seminarioReact
+            classroom = classroomRepository.findByName("Aula A28").orElseThrow { NotFoundException("No se halló el aula") }
+        }
+        scheduleRepository.save(scheduleSeminarioReact)
+
+        //Sin Iniciar
+        val scheduleConferenciaCloud = Schedule(
+                startTime = LocalTime.of(23, 45),
+                endTime = LocalTime.of(23, 59),
+                weekDay = null,
+                date = LocalDate.now(),
+                isVirtual = true
+        ).apply {
+            event = conferenciaCloud
+        }
+        scheduleRepository.save(scheduleConferenciaCloud)
+
+        val scheduleCharlaKubernetes = Schedule(
+                startTime = LocalTime.of(23, 50),
+                endTime = LocalTime.of(23, 59),
+                weekDay = null,
+                date = LocalDate.now(),
+                isVirtual = false
+        ).apply {
+                event = charlaKubernetes
+                classroom = classroomRepository .findByName("Centro de investigacion y desarrollo de informatica").orElseThrow { NotFoundException("No se halló el aula") }
+        }
+        scheduleRepository.save(scheduleCharlaKubernetes)
+
+        //Finalizados
+        val scheduleSeminarioDocker = Schedule(
+                startTime = LocalTime.of(8, 0),
+                endTime = LocalTime.of(10, 0),
+                weekDay = null,
+                date = LocalDate.now(),
+                isVirtual = false
+        ).apply {
+            event = seminarioDocker
+            classroom = classroomRepository.findByName("Aula A4 - ITS").orElseThrow { NotFoundException("No se halló el aula") }
+        }
+        scheduleRepository.save(scheduleSeminarioDocker)
+
+
+        val scheduleCharlaGit = Schedule(
+                startTime = LocalTime.of(12, 0),
+                endTime = LocalTime.of(13, 30),
+                weekDay = null,
+                date = LocalDate.now(),
+                isVirtual = true
+            ).
+        apply {
+            event = charlaGit
+        }
+        scheduleRepository.save(scheduleCharlaGit)
+
+        val scheduleConferenciaIndustria = Schedule(
+                startTime = LocalTime.of(18, 0),
+                endTime = LocalTime.of(21, 0),
+                weekDay = null,
+                date = LocalDate.now().plusDays(1),
+                isVirtual = true
+            ).
+        apply {
+            event = conferenciaIndustria
+        }
+        scheduleRepository.save(scheduleConferenciaIndustria)
+
+        val scheduleCharlaCiberseguridad = Schedule(
+                startTime = LocalTime.of(10, 0),
+                endTime = LocalTime.of(12, 0),
+                weekDay = null,
+                date = LocalDate.now().plusDays(2),
+                isVirtual = false
+        ).apply {
+            event = charlaCiberseguridad
+            classroom = classroomRepository.findByName("Aula A28").orElseThrow { NotFoundException("No se halló el aula") }
+        }
+        scheduleRepository.save(scheduleCharlaCiberseguridad)
+
+        val scheduleSeminarioIA = Schedule(
+                startTime = LocalTime.of(16, 0),
+                endTime = LocalTime.of(18, 0),
+                weekDay = null,
+                date = LocalDate.now().plusDays(3),
+                isVirtual = false
+        ).apply {
+            event = seminarioIA
+            classroom = classroomRepository .findByName("Laboratorio de Computación 1").orElseThrow { NotFoundException("No se halló el aula") }
+        }
+        scheduleRepository.save(scheduleSeminarioIA)
+
+        val scheduleConferenciaDatos = Schedule(
+                startTime = LocalTime.of(19, 0),
+                endTime = LocalTime.of(22, 0),
+                weekDay = null,
+                date = LocalDate.now().plusDays(4),
+                isVirtual = true
+            ).
+        apply {
+            event = conferenciaDatos
+        }
+        scheduleRepository.save(scheduleConferenciaDatos)
+
+        //En curso
+        val scheduleCharlaQuimicaGeneral= Schedule(
+            startTime = LocalTime.of(18, 0),
+            endTime = LocalTime.of(23, 0),
+            weekDay = null,
+            date = LocalDate.now(),
+            isVirtual = false
+        ).apply {
+            event = charlaQuimicaGeneral
+            classroom = classroomRepository.findByName("Centro de investigacion y desarrollo de informatica").orElseThrow { NotFoundException("No se halló el aula") }
+        }
+        scheduleRepository.save(scheduleCharlaQuimicaGeneral)
     }
 
     fun findEvent(name: String): Event {

--- a/src/main/kotlin/ar/edu/unsam/pds/controllers/EventController.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/controllers/EventController.kt
@@ -185,13 +185,13 @@ class EventController : UUIDValid() {
         )
     }
 
-    @GetMapping("/institutional")
-    @Operation(summary = "Get institutional events")
-    fun getInstitutionalEvents(): ResponseEntity<CustomResponse> {
+    @GetMapping("/institutional/today")
+    @Operation(summary = "Get information on the day's institutional events")
+    fun getInstitutionalEventsDashboard(): ResponseEntity<CustomResponse> {
         return ResponseEntity.ok(
             CustomResponse(
-                message = "Eventos institucionales obtenidos con éxito",
-                data = eventService.getInstitutionalEvents()
+                message = "Eventos institucionales del día obtenidos con éxito",
+                data = eventService.getInstitutionalEventsDashboard()
             )
         )
     }

--- a/src/main/kotlin/ar/edu/unsam/pds/controllers/EventController.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/controllers/EventController.kt
@@ -3,6 +3,7 @@ package ar.edu.unsam.pds.controllers
 import ar.edu.unsam.pds.dto.request.EventRequestDto
 import ar.edu.unsam.pds.dto.response.CustomResponse
 import ar.edu.unsam.pds.mappers.EventMapper
+import ar.edu.unsam.pds.mappers.InstitutionalEventMapper
 import ar.edu.unsam.pds.mappers.ScheduleMapper
 import ar.edu.unsam.pds.repository.ClassroomRepository
 import ar.edu.unsam.pds.services.CourseService
@@ -180,6 +181,17 @@ class EventController : UUIDValid() {
             CustomResponse(
                 message = "Evento rechazado con éxito",
                 data = EventMapper.buildEventDto(eventService.reject(id))
+            )
+        )
+    }
+
+    @GetMapping("/institutional")
+    @Operation(summary = "Get institutional events")
+    fun getInstitutionalEvents(): ResponseEntity<CustomResponse> {
+        return ResponseEntity.ok(
+            CustomResponse(
+                message = "Eventos institucionales obtenidos con éxito",
+                data = eventService.getInstitutionalEvents()
             )
         )
     }

--- a/src/main/kotlin/ar/edu/unsam/pds/dto/response/InstitutionalEventResponseDto.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/dto/response/InstitutionalEventResponseDto.kt
@@ -1,0 +1,24 @@
+package ar.edu.unsam.pds.dto.response
+
+import java.time.LocalDate
+
+
+data class InstitutionalEventResponseDto(
+    val id: String,
+    val name: String,
+    val type: String,
+    val details: String,
+    val startDate: LocalDate?,
+    val startTime: String?,
+    val endTime: String?,
+    val location: String?,
+    val isVirtual: Boolean,
+    val professors: List<String>,
+)
+
+data class InstitutionalEventsResponseDto(
+    val current: List<InstitutionalEventResponseDto>,
+    val pendingToday: List<InstitutionalEventResponseDto>,
+    val finished: List<InstitutionalEventResponseDto>,
+    val upcoming: List<InstitutionalEventResponseDto>
+)

--- a/src/main/kotlin/ar/edu/unsam/pds/dto/response/InstitutionalEventResponseDto.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/dto/response/InstitutionalEventResponseDto.kt
@@ -12,8 +12,7 @@ data class InstitutionalEventResponseDto(
     val startTime: String?,
     val endTime: String?,
     val location: String?,
-    val isVirtual: Boolean,
-    val professors: List<String>,
+    val isVirtual: Boolean
 )
 
 data class InstitutionalEventsResponseDto(

--- a/src/main/kotlin/ar/edu/unsam/pds/mappers/InstitutionalEventMapper.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/mappers/InstitutionalEventMapper.kt
@@ -1,0 +1,29 @@
+package ar.edu.unsam.pds.mappers
+
+import ar.edu.unsam.pds.dto.response.InstitutionalEventResponseDto
+import ar.edu.unsam.pds.models.Event
+
+object InstitutionalEventMapper {
+
+    fun buildDto(event: Event): InstitutionalEventResponseDto {
+        val schedule = event.schedules.firstOrNull()
+
+        return InstitutionalEventResponseDto(
+            id = event.id.toString(),
+            name = event.name,
+            type = event.type.name,
+            details = event.details,
+            startDate = schedule?.date,
+            startTime = schedule?.startTime?.toString(),
+            endTime = schedule?.endTime?.toString(),
+            location = if (schedule?.isVirtual == true)
+                "Virtual"
+            else
+                schedule?.classroom?.let {
+                    "${it.name} - ${it.building?.name ?: ""}"
+                },
+            isVirtual = schedule?.isVirtual ?: false,
+            professors = schedule?.assignedUsers!!.map { it.lastName+", "+it.name }
+        )
+    }
+}

--- a/src/main/kotlin/ar/edu/unsam/pds/mappers/InstitutionalEventMapper.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/mappers/InstitutionalEventMapper.kt
@@ -22,8 +22,7 @@ object InstitutionalEventMapper {
                 schedule?.classroom?.let {
                     "${it.name} - ${it.building?.name ?: ""}"
                 },
-            isVirtual = schedule?.isVirtual ?: false,
-            professors = schedule?.assignedUsers?.map { "${it.lastName}, ${it.name}" } ?: emptyList()
+            isVirtual = schedule?.isVirtual ?: false
         )
     }
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/mappers/InstitutionalEventMapper.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/mappers/InstitutionalEventMapper.kt
@@ -23,7 +23,7 @@ object InstitutionalEventMapper {
                     "${it.name} - ${it.building?.name ?: ""}"
                 },
             isVirtual = schedule?.isVirtual ?: false,
-            professors = schedule?.assignedUsers!!.map { it.lastName+", "+it.name }
+            professors = schedule?.assignedUsers?.map { "${it.lastName}, ${it.name}" } ?: emptyList()
         )
     }
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/repository/EventRepository.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/repository/EventRepository.kt
@@ -82,7 +82,7 @@ interface EventRepository : JpaRepository<Event, UUID> {
           AND s.startTime <= CURRENT_TIME
           AND s.endTime >= CURRENT_TIME
     """)
-    fun findCurrentInstitutionalEvents(): List<Event>   //Eventos  de hoy que ya empezaron y todavía no terminaron
+    fun findInstitutionalEventsInProgressToday(): List<Event>   //Eventos  de hoy que ya empezaron y todavía no terminaron
 
     @EntityGraph(attributePaths = ["course", "course.programs", "schedules", "schedules.classroom", "schedules.classroom.building", "schedules.assignedUsers"])
     @Query("""
@@ -94,7 +94,7 @@ interface EventRepository : JpaRepository<Event, UUID> {
           AND s.date = CURRENT_DATE
           AND s.startTime > CURRENT_TIME
     """)
-    fun findPendingTodayInstitutionalEvents(): List<Event>  //Eventos sin iniciar
+    fun findTodayNotStartedInstitutionalEvents(): List<Event>  //Eventos sin iniciar
 
     @EntityGraph(attributePaths = ["course", "course.programs", "schedules", "schedules.classroom", "schedules.classroom.building", "schedules.assignedUsers"])
     @Query("""
@@ -118,5 +118,5 @@ interface EventRepository : JpaRepository<Event, UUID> {
           AND s.date > CURRENT_DATE
           AND s.date <= :endDate
     """)
-    fun findUpcomingInstitutionalEvents(@Param("endDate") endDate: LocalDate): List<Event>  //Eventos que ocurren durante la semana
+    fun findInstitutionalEventsForNextDays(@Param("endDate") endDate: LocalDate): List<Event>  //Eventos que ocurren durante la semana
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/repository/EventRepository.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/repository/EventRepository.kt
@@ -71,4 +71,52 @@ interface EventRepository : JpaRepository<Event, UUID> {
     @EntityGraph(attributePaths = ["schedules", "course", "course.programs", "schedules.classroom", "schedules.classroom.building", "schedules.assignedUsers"])
     fun findByIsApprovedIsNull(): List<Event>
 
+    @EntityGraph(attributePaths = ["course", "course.programs", "schedules", "schedules.classroom", "schedules.classroom.building", "schedules.assignedUsers"])
+    @Query("""
+        SELECT DISTINCT e
+        FROM Event e
+        JOIN e.schedules s
+        WHERE e.isApproved = true
+          AND e.type IN ('CHARLA', 'SEMINARIO', 'CONFERENCIA')
+          AND s.date = CURRENT_DATE
+          AND s.startTime <= CURRENT_TIME
+          AND s.endTime >= CURRENT_TIME
+    """)
+    fun findCurrentInstitutionalEvents(): List<Event>   //Eventos  de hoy que ya empezaron y todavía no terminaron
+
+    @EntityGraph(attributePaths = ["course", "course.programs", "schedules", "schedules.classroom", "schedules.classroom.building", "schedules.assignedUsers"])
+    @Query("""
+        SELECT DISTINCT e
+        FROM Event e
+        JOIN e.schedules s
+        WHERE e.isApproved = true
+          AND e.type IN ('CHARLA', 'SEMINARIO', 'CONFERENCIA')
+          AND s.date = CURRENT_DATE
+          AND s.startTime > CURRENT_TIME
+    """)
+    fun findPendingTodayInstitutionalEvents(): List<Event>  //Eventos sin iniciar
+
+    @EntityGraph(attributePaths = ["course", "course.programs", "schedules", "schedules.classroom", "schedules.classroom.building", "schedules.assignedUsers"])
+    @Query("""
+        SELECT DISTINCT e
+        FROM Event e
+        JOIN e.schedules s
+        WHERE e.isApproved = true
+          AND e.type IN ('CHARLA', 'SEMINARIO', 'CONFERENCIA')
+          AND s.date = CURRENT_DATE
+          AND s.endTime < CURRENT_TIME
+    """)
+    fun findFinishedTodayInstitutionalEvents(): List<Event> //Eventos que ya terminaron
+
+    @EntityGraph(attributePaths = ["course", "course.programs", "schedules", "schedules.classroom", "schedules.classroom.building", "schedules.assignedUsers"])
+    @Query("""
+        SELECT DISTINCT e
+        FROM Event e
+        JOIN e.schedules s
+        WHERE e.isApproved = true
+          AND e.type IN ('CHARLA', 'SEMINARIO', 'CONFERENCIA')
+          AND s.date > CURRENT_DATE
+          AND s.date <= :endDate
+    """)
+    fun findUpcomingInstitutionalEvents(@Param("endDate") endDate: LocalDate): List<Event>  //Eventos que ocurren durante la semana
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/security/FilterChainConfiguration.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/security/FilterChainConfiguration.kt
@@ -57,6 +57,7 @@ class FilterChainConfiguration {
                 antMatcher(POST, "/api/events/*/reject"),
                 antMatcher(GET, "/api/events/pending"),
                 antMatcher(GET, "/api/classroom"),
+                antMatcher(GET, "/api/events/institutional"),
             ).permitAll()
             //TODO: volver a cambiar a has role admin despues de probar
 

--- a/src/main/kotlin/ar/edu/unsam/pds/services/EventService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/EventService.kt
@@ -159,11 +159,13 @@ class EventService(
     }
 
     fun getInstitutionalEvents(): InstitutionalEventsResponseDto {
+        val sevenDaysFromNow = LocalDate.now().plusDays(7)
+
         return InstitutionalEventsResponseDto(
             current = eventRepository.findCurrentInstitutionalEvents().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime },
             pendingToday = eventRepository.findPendingTodayInstitutionalEvents().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime },
             finished = eventRepository.findFinishedTodayInstitutionalEvents().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime },
-            upcoming = eventRepository.findUpcomingInstitutionalEvents().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime }
+            upcoming = eventRepository.findUpcomingInstitutionalEvents(sevenDaysFromNow).map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime }
         )
     }
 

--- a/src/main/kotlin/ar/edu/unsam/pds/services/EventService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/EventService.kt
@@ -158,14 +158,14 @@ class EventService(
         return eventRepository.save(event)
     }
 
-    fun getInstitutionalEvents(): InstitutionalEventsResponseDto {
+    fun getInstitutionalEventsDashboard(): InstitutionalEventsResponseDto {
         val sevenDaysFromNow = LocalDate.now().plusDays(7)
 
         return InstitutionalEventsResponseDto(
-            current = eventRepository.findCurrentInstitutionalEvents().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime },
-            pendingToday = eventRepository.findPendingTodayInstitutionalEvents().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime },
+            current = eventRepository.findInstitutionalEventsInProgressToday().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime },
+            pendingToday = eventRepository.findTodayNotStartedInstitutionalEvents().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime },
             finished = eventRepository.findFinishedTodayInstitutionalEvents().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime },
-            upcoming = eventRepository.findUpcomingInstitutionalEvents(sevenDaysFromNow).map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime }
+            upcoming = eventRepository.findInstitutionalEventsForNextDays(sevenDaysFromNow).map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime }
         )
     }
 

--- a/src/main/kotlin/ar/edu/unsam/pds/services/EventService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/EventService.kt
@@ -3,8 +3,10 @@ package ar.edu.unsam.pds.services
 import ar.edu.unsam.pds.dto.request.EventRequestDto
 import ar.edu.unsam.pds.dto.response.EventDetailResponseDto
 import ar.edu.unsam.pds.dto.response.EventResponseDto
+import ar.edu.unsam.pds.dto.response.InstitutionalEventsResponseDto
 import ar.edu.unsam.pds.exceptions.NotFoundException
 import ar.edu.unsam.pds.mappers.EventMapper
+import ar.edu.unsam.pds.mappers.InstitutionalEventMapper
 import ar.edu.unsam.pds.mappers.ScheduleMapper
 import ar.edu.unsam.pds.models.Event
 import ar.edu.unsam.pds.models.Schedule
@@ -154,6 +156,15 @@ class EventService(
         val event = findByID(id)
         event.isApproved = false
         return eventRepository.save(event)
+    }
+
+    fun getInstitutionalEvents(): InstitutionalEventsResponseDto {
+        return InstitutionalEventsResponseDto(
+            current = eventRepository.findCurrentInstitutionalEvents().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime },
+            pendingToday = eventRepository.findPendingTodayInstitutionalEvents().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime },
+            finished = eventRepository.findFinishedTodayInstitutionalEvents().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime },
+            upcoming = eventRepository.findUpcomingInstitutionalEvents().map { InstitutionalEventMapper.buildDto(it) }.sortedBy { it.startTime }
+        )
     }
 
 }


### PR DESCRIPTION
Buenas!
Agregué  la funcionalidad para listar los eventos institucionales que van a ocurrir durante el día a través del nuevo endpoint GET /institutional. 
<img width="780" height="310" alt="idea64_89o8qyq8tH" src="https://github.com/user-attachments/assets/f6abdfe7-c41f-46f9-b8fd-b7b6d931228b" />  
La lógica de negocio implementada va a mostrar únicamente eventos de tipo CHARLA, SEMINARIO y CONFERENCIA, es decir, eventos globales y no académicos específicos como parciales o finales.
Spoilers del Front, de como se verían
<img width="1289" height="1893" alt="imagen" src="https://github.com/user-attachments/assets/596ac706-f12d-4414-9f11-212b78d5e13b" />

Para ello se implementaron `InstitutionalEventResponseDto` y `InstitutionalEventsResponseDto` 
<img width="650" height="589" alt="idea64_UXWOnJjcHq" src="https://github.com/user-attachments/assets/a1c3e8e3-0656-4fa3-a273-3cfbd47ac970" />

y un componente InstitutionalEventMapper encargado de realizar la transformación desde el modelo de dominio Event. 

El service retorna la información clasificada por estado 
* En curso
<img width="465" height="292" alt="Bruno_VbNVcrcJ0w" src="https://github.com/user-attachments/assets/353a9614-0d75-4e57-8f84-7e8e1bdb42dc" />

* Proximo
<img width="653" height="666" alt="Bruno_EwaC7X17Z8" src="https://github.com/user-attachments/assets/2b524b8a-97b7-4c86-a2ff-c1fac5cae777" />

* Finalizado
<img width="390" height="256" alt="Bruno_if9s2WyTV7" src="https://github.com/user-attachments/assets/f59e8512-fece-469f-a61e-215444df8f9a" />

* Proximos eventos
<img width="510" height="664" alt="Bruno_FiMnkN2bq0" src="https://github.com/user-attachments/assets/0b71738f-781e-4074-8563-62c8e12931a5" />
