### PR TITLE
Cambios de eventos no asociados a materias.

### DIFF
--- a/src/main/kotlin/ar/edu/unsam/pds/controllers/EventController.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/controllers/EventController.kt
@@ -4,6 +4,7 @@ import ar.edu.unsam.pds.dto.request.EventRequestDto
 import ar.edu.unsam.pds.dto.response.CustomResponse
 import ar.edu.unsam.pds.mappers.EventMapper
 import ar.edu.unsam.pds.mappers.ScheduleMapper
+import ar.edu.unsam.pds.models.enums.EventType
 import ar.edu.unsam.pds.repository.ClassroomRepository
 import ar.edu.unsam.pds.services.CourseService
 import ar.edu.unsam.pds.services.EventService
@@ -25,6 +26,40 @@ class EventController : UUIDValid() {
     lateinit var eventService: EventService
     @Autowired
     lateinit var courseService: CourseService
+
+    // ──────────────────────────────────────────────────────────────
+    // IMPORTANTE: los endpoints con path fijo van ANTES que /{id}
+    // para que Spring no intente parsear "institutional" como UUID
+    // ──────────────────────────────────────────────────────────────
+
+    @GetMapping("/institutional")
+    @Operation(summary = "Get all standalone institutional events (CHARLA, SEMINARIO, CONFERENCIA)")
+    fun getInstitutionalEvents(
+        @RequestParam(value = "query", required = false) query: String?
+    ): ResponseEntity<CustomResponse> {
+        val events = if (!query.isNullOrBlank()) {
+            eventService.searchStandaloneEvents(query)
+        } else {
+            eventService.getStandaloneEvents()
+        }
+        return ResponseEntity.ok(
+            CustomResponse(
+                message = "Eventos institucionales obtenidos con éxito",
+                data = events.map { EventMapper.buildEventDto(it) }
+            )
+        )
+    }
+
+    @GetMapping("/pending")
+    @Operation(summary = "Get all pending event requests")
+    fun getPendingRequests(): ResponseEntity<CustomResponse> {
+        return ResponseEntity.status(200).body(
+            CustomResponse(
+                message = "Solicitudes pendientes obtenidas con éxito",
+                data = eventService.getPendingRequests().map { EventMapper.buildEventDto(it) }
+            )
+        )
+    }
 
     @GetMapping("/{classroomID}/{date}")
     @Operation(summary = "Get all events in a given classroom")
@@ -71,8 +106,7 @@ class EventController : UUIDValid() {
 
     @GetMapping
     @Operation(summary = "Get all events")
-    fun getAllEvents(
-    ): ResponseEntity<CustomResponse> {
+    fun getAllEvents(): ResponseEntity<CustomResponse> {
         val events = eventService.getAll()
         return ResponseEntity.status(200).body(
             CustomResponse(
@@ -82,12 +116,15 @@ class EventController : UUIDValid() {
         )
     }
 
-
     @PostMapping
     @Operation(summary = "Create an event")
     fun createEvent(
         @RequestBody @Valid eventDTO: EventRequestDto
     ): ResponseEntity<CustomResponse> {
+
+        // Validar coherencia tipo ↔ curso
+        val eventType = EventType.valueOf(eventDTO.type)
+        eventService.validateEventTypeCourseCoherence(eventType, eventDTO.courseID)
 
         val course = if (!eventDTO.courseID.isNullOrBlank()) courseService.findByID(eventDTO.courseID) else null
         val event = EventMapper.buildEvent(eventDTO, course)
@@ -139,23 +176,12 @@ class EventController : UUIDValid() {
     ): ResponseEntity<CustomResponse> {
         requireNotNull(eventDTO.id) { "El ID del evento no debe ser nulo" }
 
-        val updatedEvent = eventService.update(eventDTO)       // ← pasamos sólo el DTO
+        val updatedEvent = eventService.update(eventDTO)
 
         return ResponseEntity.status(200).body(
             CustomResponse(
                 message = "Event editado con éxito",
                 data = EventMapper.buildEventDto(updatedEvent)
-            )
-        )
-    }
-
-    @GetMapping("/pending")
-    @Operation(summary = "Get all pending event requests")
-    fun getPendingRequests(): ResponseEntity<CustomResponse> {
-        return ResponseEntity.status(200).body(
-            CustomResponse(
-                message = "Solicitudes pendientes obtenidas con éxito",
-                data = eventService.getPendingRequests().map { EventMapper.buildEventDto(it) }
             )
         )
     }

--- a/src/main/kotlin/ar/edu/unsam/pds/repository/EventRepository.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/repository/EventRepository.kt
@@ -1,6 +1,7 @@
 package ar.edu.unsam.pds.repository
 
 import ar.edu.unsam.pds.models.Event
+import ar.edu.unsam.pds.models.enums.EventType
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -71,4 +72,23 @@ interface EventRepository : JpaRepository<Event, UUID> {
     @EntityGraph(attributePaths = ["schedules", "course", "course.programs", "schedules.classroom", "schedules.classroom.building", "schedules.assignedUsers"])
     fun findByIsApprovedIsNull(): List<Event>
 
+    // Eventos institucionales (sin curso asociado)
+
+    @EntityGraph(attributePaths = ["schedules", "schedules.classroom", "schedules.classroom.building", "schedules.assignedUsers"])
+    @Query("SELECT e FROM Event e WHERE e.course IS NULL AND e.type IN :types")
+    fun findStandaloneByTypes(@Param("types") types: List<EventType>): List<Event>
+
+    // Búsqueda de eventos institucionales por nombre
+
+    @EntityGraph(attributePaths = ["schedules", "schedules.classroom", "schedules.classroom.building", "schedules.assignedUsers"])
+    @Query("""
+        SELECT e FROM Event e
+        WHERE e.course IS NULL
+          AND e.type IN :types
+          AND LOWER(e.name) LIKE LOWER(CONCAT('%', :query, '%'))
+    """)
+    fun searchStandaloneByName(
+        @Param("types") types: List<EventType>,
+        @Param("query") query: String
+    ): List<Event>
 }

--- a/src/main/kotlin/ar/edu/unsam/pds/services/EventService.kt
+++ b/src/main/kotlin/ar/edu/unsam/pds/services/EventService.kt
@@ -4,6 +4,7 @@ import ar.edu.unsam.pds.dto.request.EventRequestDto
 import ar.edu.unsam.pds.dto.response.EventDetailResponseDto
 import ar.edu.unsam.pds.dto.response.EventResponseDto
 import ar.edu.unsam.pds.exceptions.NotFoundException
+import ar.edu.unsam.pds.exceptions.ValidationException
 import ar.edu.unsam.pds.mappers.EventMapper
 import ar.edu.unsam.pds.mappers.ScheduleMapper
 import ar.edu.unsam.pds.models.Event
@@ -20,25 +21,55 @@ import java.util.*
 @Service
 class EventService(
     private val eventRepository: EventRepository,
-    private val courseService:CourseService,
+    private val courseService: CourseService,
     private val periodService: PeriodService,
     private val classroomRepository: ClassroomRepository,
     private val scheduleRepository: ScheduleRepository
 ) {
 
-    fun getAll():List<Event>{
+    companion object {
+        val INSTITUTIONAL_TYPES = listOf(EventType.CHARLA, EventType.SEMINARIO, EventType.CONFERENCIA)
+        val ACADEMIC_TYPES      = listOf(EventType.CURSADA, EventType.PARCIAL, EventType.FINAL)
+    }
+
+    fun getAll(): List<Event> {
         return eventRepository.findAll()
     }
 
-    @Transactional(readOnly = true)
-    fun searchBy(classroomID: String, date: LocalDate): List<Event> = eventRepository.findEventsByClassroomAndDate(classroomID, date, date.dayOfWeek)
+    // ──────────────────────────────────────────────
+    // NUEVO: eventos institucionales (sin curso)
+    // ──────────────────────────────────────────────
+    fun getStandaloneEvents(): List<Event> {
+        return eventRepository.findStandaloneByTypes(INSTITUTIONAL_TYPES)
+    }
 
-    fun findByID(id:String?):Event{
-        val eventID= UUID.fromString(id)
+    fun searchStandaloneEvents(query: String): List<Event> {
+        return eventRepository.searchStandaloneByName(INSTITUTIONAL_TYPES, query)
+    }
+
+    // ──────────────────────────────────────────────
+    // NUEVO: validación de coherencia tipo ↔ curso
+    // ──────────────────────────────────────────────
+    fun validateEventTypeCourseCoherence(type: EventType, courseID: String?) {
+        if (type in ACADEMIC_TYPES && courseID.isNullOrBlank()) {
+            throw ValidationException("Los eventos de tipo ${type.name} requieren un curso asociado")
+        }
+        if (type in INSTITUTIONAL_TYPES && !courseID.isNullOrBlank()) {
+            throw ValidationException("Los eventos de tipo ${type.name} no deben tener un curso asociado")
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun searchBy(classroomID: String, date: LocalDate): List<Event> =
+        eventRepository.findEventsByClassroomAndDate(classroomID, date, date.dayOfWeek)
+
+    fun findByID(id: String?): Event {
+        val eventID = UUID.fromString(id)
         return eventRepository.findById(eventID).orElseThrow {
             NotFoundException("Evento no encontrado para el uuid suministrado")
         }
     }
+
     fun getEvent(eventId: String): EventResponseDto? {
         val eventUUID = UUID.fromString(eventId)
         val matchingEvent = eventRepository.findById(eventUUID)
@@ -55,17 +86,20 @@ class EventService(
         return EventMapper.buildEventDetailDto(matchingEvent)
     }
 
-    fun addSchedules(event: Event, schedules: List<Schedule>){
+    fun addSchedules(event: Event, schedules: List<Schedule>) {
         event.addSchedules(schedules)
     }
 
-    fun addPeriod(event:Event, periodID:String?){
+    fun addPeriod(event: Event, periodID: String?) {
         val period = periodService.getById(periodID)
         event.addPeriod(period)
     }
 
     @Transactional
     fun update(eventDto: EventRequestDto): Event {
+
+        val eventType = EventType.valueOf(eventDto.type)
+        validateEventTypeCourseCoherence(eventType, eventDto.courseID)
 
         val existingEvent = findByID(eventDto.id)
 
@@ -75,7 +109,7 @@ class EventService(
             isCancelled       = eventDto.isCancelled
             course            = if (!eventDto.courseID.isNullOrBlank()) courseService.findByID(eventDto.courseID) else null
             period            = if (!eventDto.periodID.isNullOrBlank()) periodService.getById(eventDto.periodID) else null
-            type              = EventType.valueOf(eventDto.type)
+            type              = eventType
             details           = eventDto.details ?: ""
             customPeriodStart = eventDto.customPeriodStart
             customPeriodEnd   = eventDto.customPeriodEnd
@@ -119,7 +153,7 @@ class EventService(
     }
 
     @Transactional
-    fun create(newEvent: Event):Event{
+    fun create(newEvent: Event): Event {
         eventRepository.save(newEvent)
         return newEvent
     }
@@ -155,5 +189,4 @@ class EventService(
         event.isApproved = false
         return eventRepository.save(event)
     }
-
 }


### PR DESCRIPTION
# Separar eventos institucionales de eventos académicos (Back)
 
## Descripción
 
Se agrega soporte para diferenciar **eventos académicos** (CURSADA, PARCIAL, FINAL — siempre asociados a un curso) de **eventos institucionales** (CHARLA, SEMINARIO, CONFERENCIA — independientes, sin curso).
 
Se expone un nuevo endpoint para consultar eventos institucionales y se agrega validación de coherencia entre el tipo de evento y la presencia/ausencia de curso.
 
**No se modifican Course, CourseService, CourseController ni CourseRepository** porque la relación Course → Event ya funciona: el EntityGraph de `CourseRepository.findById` carga los eventos del curso con sus schedules completos, y el front se encarga de filtrar por tipo (cursada vs exámenes) en el cliente.
 
---
 
@MelOviedo No me di cuenta y armé la rama desde develop con lo cual, no me di cuenta que no tenía tus cambios. Hago el pr y vemos si va y sino armo otra rama desde la tuya con las modificaciones necesarias. 
